### PR TITLE
Remove CAP REQ

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -2571,9 +2571,6 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
     def doTopic(self, irc, msg):
         self.handleMsg(irc,msg,False)
 
-    def do903 (self,irc,msg):
-        irc.queueMsg(ircmsgs.IrcMsg('CAP REQ :extended-join account-notify'))
-
     def handleFloodSnote (self,irc,text):
         user = text.split('Possible Flooder ')[1]
         a = user[::-1]


### PR DESCRIPTION
Limnoria requests these capabilities since forever, and requesting them on
RPL_SASLSUCCESS causes InspIRCd to reply with CAP ACK after we
send CAP END, but before it sends the MOTD; which Limnoria's current
release does not expect and complains loudly about.

This will be fixed in Limnoria's next, though:
https://github.com/progval/Limnoria/commit/9ec4eb956306efb93597d751c6cab89af31bd090